### PR TITLE
tmux.conf supports >2.9 versions

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -92,27 +92,17 @@ set -g status-position top
 set -g status-justify left
 set -g status-bg $color_background
 set -g status-fg $color_foreground
-set -g status-attr dim
 set -g status-left ''
 set -g status-right "#[fg=${color_foreground},bg=${color_selection},bold] %d/%m #[fg=${color_foreground},bg=${color_selection},bold] %H:%M:%S "
 set -g status-right-length 50
 set -g status-left-length 20
 
-setw -g window-status-current-fg $color_yellow
-setw -g window-status-current-bg $color_selection
-setw -g window-status-current-attr bold
+setw -g window-status-current-style fg=$color_yellow,bg=$color_selection,bold 
 setw -g window-status-current-format " #I#[fg=colour249]:#[fg=${color_yellow}]#W#[fg=$color_red]#F "
 
-setw -g window-status-fg $color_foreground
-setw -g window-status-bg $color_background
-setw -g window-status-attr none
+setw -g window-status-style fg=$color_foreground,bg=$color_background
 setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244]#F '
-
-setw -g window-status-bell-attr bold
-setw -g window-status-bell-fg $color_purple
-setw -g window-status-bell-bg $color_selection
+setw -g window-status-bell-style fg=$color_purple,bg=$color_selection,bold
 
 # messages
-set -g message-attr bold
-set -g message-fg $color_red
-set -g message-bg $color_selection
+set -g message-style fg=$color_red,bg=$color_selection,bold


### PR DESCRIPTION
tmux.conf version 2.9 breaks some options related to styles - https://github.com/tmux/tmux/issues/1689

This following link describes how to translate the old style to the new style - https://github.com/tmux/tmux/wiki/FAQ#how-do-i-translate--fg--bg-and--attr-options-into--style-options

